### PR TITLE
Don't try to read the entire file for GetFileJob

### DIFF
--- a/mqterm/jobs.py
+++ b/mqterm/jobs.py
@@ -92,7 +92,7 @@ class GetFileJob(Job):
     argc = 1
 
     def output(self):
-        return BytesIO(open(self.args[0], "rb").read())
+        return open(self.args[0], "rb")
 
 
 class WhoAmIJob(Job):

--- a/tests/e2e/e2e_file_ops.py
+++ b/tests/e2e/e2e_file_ops.py
@@ -15,9 +15,8 @@ from mqterm.terminal import MqttTerminal, format_properties
 # Set up logging; pass LOG_LEVEL=DEBUG if needed for local testing
 logger = logging.getLogger()
 logger.setLevel(getattr(logging, os.getenv("LOG_LEVEL", "WARNING").upper()))
-formatter = logging.Formatter(
-    "%(asctime)s.%(msecs)d - %(levelname)s - %(name)s - %(message)s"
-)
+format_str = "%(asctime)s.%(msecs)03.0f - %(levelname)s - %(name)s - %(message)s"
+formatter = logging.Formatter(format_str)
 handler = logging.StreamHandler(sys.stdout)
 handler.setFormatter(formatter)
 logger.handlers = []


### PR DESCRIPTION
Since open() returns a BytesIO when we pass "rb", no need to read
the whole thing out then re-wrap it in a BytesIO.
